### PR TITLE
[Greedy] 5주차

### DIFF
--- a/naarang/Greedy/BOJ_1092.js
+++ b/naarang/Greedy/BOJ_1092.js
@@ -1,0 +1,38 @@
+const fs = require("fs");
+let input = fs.readFileSync("naarang/input.txt").toString().trim().split("\n");
+let n = Number(input[0]);
+let crains = input[1]
+  .split(" ")
+  .map(Number)
+  .sort((a, b) => a - b);
+let m = Number(input[2]);
+let boxes = input[3]
+  .split(" ")
+  .map(Number)
+  .sort((a, b) => b - a);
+
+let crainBox = Array(n).fill(0); // crain별로 가지는 박스 개수
+for (let i = 0; i < m; i++) {
+  const box = boxes[i];
+  const crainIndex = crains.findIndex((value) => value >= box);
+  if (crainIndex === -1) {
+    console.log(-1);
+    return;
+  }
+
+  let min = Infinity;
+  let minIndex = n - 1;
+  for (let j = n - 1; j >= crainIndex; j--) {
+    if (crainBox[j] < min) {
+      minIndex = j;
+      min = crainBox[j];
+    }
+  }
+  crainBox[minIndex]++;
+}
+
+console.log(Math.max(...crainBox));
+
+// crain은 무게 제한이 작은것부터 정렬!
+// box는 무게가 큰것부터 정렬!
+// 무게가 큰 box부터 어떤 crain에 넣을지 결정하자! -> 여러 crain이 가능할 경우 가장 적은 개수를 담당한 crain에게 주자!

--- a/naarang/Greedy/BOJ_11000.js
+++ b/naarang/Greedy/BOJ_11000.js
@@ -1,0 +1,52 @@
+const fs = require("fs");
+let input = fs.readFileSync("naarang/input.txt").toString().trim().split("\n");
+
+const n = Number(input.shift());
+const times = [];
+
+input.forEach((value) => {
+  const [startTime, endTime] = value.split(" ").map(Number);
+  times.push({ time: startTime, start: true });
+  times.push({ time: endTime, start: false });
+});
+
+times.sort((a, b) => (a.time === b.time ? a.start - b.start : a.time - b.time));
+
+let max = 0;
+let cur = 0;
+times.forEach((value) => {
+  if (value.start) {
+    cur++;
+    max = Math.max(max, cur);
+  } else {
+    cur--;
+  }
+});
+
+console.log(max);
+
+// 틀렸습니다 해결
+// 이 문제는 한 강의실에 최대한 많은 것을 넣는게 아니라 각 강의실에 넣어주는 것이므로 시작 시간으로 정렬해야 틀리지 않았다.
+/* 반례
+8
+1 8
+9 16
+3 7
+8 10
+10 14
+5 6
+6 11
+11 12
+*/
+
+// 이번에는 시간 초과 발생...
+/*
+앞의 회의실 배정 문제 처럼 풀었더니.. 시간 초과ㅠ
+
+정말 모르겠어서 인터넷을 참고했는데 다른 관점으로 접근했어야 했다!
+
+필요한 강의실의 수는 중첩된 강의가 가장 많은 시간의 강의의 수이므로 
+시간을 기준으로 순회를 하면서, 강의가 가장 많이 겹치는 max값을 찾아야 했다!
+
+또한 강의별 시간 정렬 시에 주의할 점이 time이 같다면, false가 앞에 와야함. 강의가 끝나고 다른 강의가 시작 되어야함한다!
+*/

--- a/naarang/Greedy/BOJ_1931.js
+++ b/naarang/Greedy/BOJ_1931.js
@@ -1,0 +1,32 @@
+const fs = require("fs");
+let input = fs.readFileSync("naarang/input.txt").toString().trim().split("\n");
+let n = Number(input.shift());
+let meetings = input
+  .map((meeting) => meeting.split(" ").map(Number))
+  .sort((a, b) => {
+    if (a[1] === b[1]) return a[0] - b[0];
+    return a[1] - b[1];
+  });
+
+let answer = 0; // 회의의 개수 최대값
+
+let lastMeetingEndTime = 0;
+for (let i = 0; i < n; i++) {
+  const [startTime, endTime] = meetings[i];
+
+  if (lastMeetingEndTime <= startTime) {
+    lastMeetingEndTime = endTime;
+    answer++;
+  }
+}
+
+console.log(answer);
+
+// 정렬을 하는게 확실히 개선하기 좋을듯!
+// 전체 시간 배열에 회의를 기록하지 않고 마지막 회의의 종료 시간만 가지고도 비교가 가능하므로!
+
+// 시간 초과 발생... -> O(N^2)에서 O(N)으로 줄임
+/*
+정렬할 때 회의 시작 시간이 아니라 회의 종료 시간 기준으로 해야 함
+-> 종료 시간이 빠를수록 더 많은 회의를 배정할 수 있으므로!!
+*/

--- a/naarang/README.md
+++ b/naarang/README.md
@@ -1,3 +1,11 @@
+#### Week 05 - Greedy (24.10.07)
+
+| 유형   | 제목                                                              | 풀이 |
+| ------ | ----------------------------------------------------------------- | :--: |
+| Greedy | [백준 1931 : 회의실 배정](https://www.acmicpc.net/problem/1931)   |
+| Greedy | [백준 1092 : 배](https://www.acmicpc.net/problem/1092)            |
+| Greedy | [백준 11000 : 강의실 배정](https://www.acmicpc.net/problem/11000) |
+
 #### Week 04 - 수학 (24.09.30)
 
 | 유형 | 제목                                                                   | 풀이 |


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 백준 1931 : 회의실 배정
- [x] 백준 1092 : 배
- [x] 백준 11000 : 강의실 배정

## ✏️ 공부 내용

### 백준 1931 : 회의실 배정

정렬을 잘하는 것이 중요했다

시간 초과가 발생했었는데 회의 종료 시간 기준으로 정렬하는 것으로 변경해서 -> O(N^2)에서 O(N)으로 줄임

정렬할 때 회의 시작 시간이 아니라 회의 종료 시간 기준으로 해야 함
-> 종료 시간이 빠를수록 더 많은 회의를 배정할 수 있으므로!!

---

### 백준 1092 : 배

어떻게 최대한 균등하게 분배할 수 있을까가 고민되었다...

crain은 무게 제한이 작은것부터 정렬!

box는 무게가 큰것부터 정렬!

무게가 큰 box부터 어떤 crain에 넣을지 결정하자! -> 여러 crain이 가능할 경우 가장 적은 개수를 담당한 crain에게 주자!

---

### 백준 11000 : 강의실 배정

틀렸습니다 해결

-> 이 문제는 한 강의실에 최대한 많은 것을 넣는게 아니라 각 강의실에 넣어주는 것이므로 시작 시간으로 정렬해야 틀리지 않았다.

찾은 반례
```
8
1 8
9 16
3 7
8 10
10 14
5 6
6 11
11 12
```

근데 이번에는 시간 초과 발생...

앞의 회의실 배정 문제 처럼 풀었더니.. 시간 초과ㅠ

정말 모르겠어서 인터넷을 참고했는데 다른 관점으로 접근했어야 했다!

필요한 강의실의 수는 중첩된 강의가 가장 많은 시간의 강의의 수이므로 
시간을 기준으로 순회를 하면서, 강의가 가장 많이 겹치는 max값을 찾아야 했다!

또한 강의별 시간 정렬 시에 주의할 점이 time이 같다면, false가 앞에 와야함했다 -> 강의가 끝나고 다른 강의가 시작 되어야하므로


## 💬 논의 사항

<!-- 논의하고 싶은 사항이나 기타 내용이 있다면 작성해주세요 -->
