### PR TITLE
[DP] 1주차

### DIFF
--- a/chungchae/DP/BOJ_10986.cpp
+++ b/chungchae/DP/BOJ_10986.cpp
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <algorithm>
+#include <cmath>
+#include <vector>
+#include <numeric>
+#include <stack>
+
+using namespace std;
+
+// BOJ_10986
+int main() {
+	ios::sync_with_stdio(false);
+	cin.tie(NULL); cout.tie(NULL);
+
+	int N, M, temp;
+	cin >> N >> M;
+	vector<long> S(N, 0);
+	vector<long> R(M, 0);
+	long answer = 0;
+	int remainder;
+
+	cin >> S[0];
+
+	for (int i = 1; i < N; i++) {
+		cin >> temp;
+		S[i] = S[i - 1] + temp;
+	}
+
+	for (int i = 0; i < N; i++) {
+		remainder = S[i] % M;
+		if (remainder == 0)
+			answer++;
+		R[remainder]++;
+	}
+
+	for (int i = 0; i < M; i++) {
+		if (R[i] > 1) {
+			answer += R[i] * (R[i] - 1) / 2;
+		}
+	}
+
+	cout << answer;
+
+}

--- a/chungchae/DP/BOJ_11659.cpp
+++ b/chungchae/DP/BOJ_11659.cpp
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <algorithm>
+#include <cmath>
+#include <vector>
+#include <numeric>
+#include <stack>
+
+using namespace std;
+
+// BOJ_11659
+int main() {
+	ios::sync_with_stdio(false);
+	cin.tie(NULL); cout.tie(NULL);
+
+	int N, M;
+	cin >> N >> M;
+
+	int S[100001] = {};
+
+	for (int i = 1; i <= N; i++) {
+		int temp;
+		cin >> temp;
+		S[i] = S[i - 1] + temp;
+	}
+
+	for (int i = 0; i < M; i++) {
+		int a, b;
+		cin >> a >> b;
+		cout << S[b] - S[a - 1] << "\n";
+	}
+
+	return 0;
+}

--- a/chungchae/DP/BOJ_11660.cpp
+++ b/chungchae/DP/BOJ_11660.cpp
@@ -1,0 +1,35 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <algorithm>
+#include <cmath>
+#include <vector>
+#include <numeric>
+#include <stack>
+
+using namespace std;
+
+// BOJ_11660
+int main() {
+	ios::sync_with_stdio(false);
+	cin.tie(NULL); cout.tie(NULL);
+
+	int N, M, temp;
+	cin >> N >> M;
+
+	vector<vector<int>> S(N + 1, vector<int>(N + 1, 0));
+	
+	for (int i = 1; i <= N; i++) {
+		for (int j = 1; j <= N; j++) {
+			cin >> temp;
+			S[i][j] = S[i][j - 1] + S[i - 1][j] - S[i - 1][j - 1] + temp;
+		}
+	}
+	int x1, y1, x2, y2;
+	for (int i = 0; i < M; i++) {
+		cin >> x1 >> y1 >> x2 >> y2;
+		cout << S[x2][y2] - S[x2][y1 - 1] - S[x1 - 1][y2] + S[x1 - 1][y1 - 1] << "\n";
+	}
+}


### PR DESCRIPTION
## ✅ 체크리스트
백준 11659: 구간 합 구하기 4
백준 11660: 구간 합 구하기 5
백준 10986: 나머지 합


## ✏️ 공부 내용
구간 합은 배열을 이용해 시간 복잡도를 줄이는 특수 알고리즘으로, 코테 사용 비율이 높음!
가장 기본적인 틀은 먼저 합 배열을 구한 뒤, 합 배열에 문제에 맞는 공식을 적용해 원하는 구간의 합을 구하기

### 11659: 구간 합 구하기 4
수 N개가 주어졌을 때 i번째 수에서 j번째 수까지의 합 구하기

이 코드를 넣으면  C의 stdio와 C++의 iostream의 동기화를 비할성화하여 C++에서 시간을 단축할 수 있다고 한다.

```
        ios::sync_with_stdio(false);
	cin.tie(NULL); cout.tie(NULL);
```

먼저 합 배열을 아래와 같이 구한다.

```
        for (int i = 1; i <= N; i++) {
		int temp;
		cin >> temp;
		S[i] = S[i - 1] + temp;
	}
```

i~j 까지 구간합은 j까지의 합 - i까지의 합 공식으로 구한다.

```
        for (int i = 0; i < M; i++) {
		int a, b;
		cin >> a >> b;
		cout << S[b] - S[a - 1] << "\n";
	}
```

시간 제한이 까다로운 문제였다. endl 보다 "\n" 출력하는게 더 빠르다고 해서 바꿔서 제출~~

### 11660: 구간 합 구하기 5

2차원 배열 내에 특정 두 좌표 사이의 합을 구하는 문제이다.

합 배열도 2차원 배열에 저장한다.

```
	for (int i = 1; i <= N; i++) {
		for (int j = 1; j <= N; j++) {
			cin >> temp;
			S[i][j] = S[i][j - 1] + S[i - 1][j] - S[i - 1][j - 1] + temp;
		}
	}
	int x1, y1, x2, y2;
	for (int i = 0; i < M; i++) {
		cin >> x1 >> y1 >> x2 >> y2;
		cout << S[x2][y2] - S[x2][y1 - 1] - S[x1 - 1][y2] + S[x1 - 1][y1 - 1] << "\n";
	}
```


### 10986: 나머지 합

수 N개 A1, A2, ..., AN이 주어진다. 이때, 연속된 부분 구간의 합이 M으로 나누어 떨어지는 구간의 개수를 구해야 한다.

즉, Ai + ... + Aj (i ≤ j) 의 합이 M으로 나누어 떨어지는 (i, j) 쌍의 개수를 구해야 한다.

합 배열을 저장하고, 주어진 M으로 %연산을 적용해 배열을 업데이트한다.

업데이트된 배열 값이 0이면 정답 카운트에 추가하고, 나머지는 같은 값의 개수끼리 N(N-1)/2 연산을 적용해 정답 카운트에 추가한다.

```
	for (int i = 0; i < N; i++) {
		remainder = S[i] % M;
		if (remainder == 0)
			answer++;
		R[remainder]++;
	}
	for (int i = 0; i < M; i++) {
		if (R[i] > 1) {
			answer += R[i] * (R[i] - 1) / 2;
		}
	}
```


## 💬 논의 사항
