### PR TITLE
[Graph Traversal/Brute Force] 3주차

### DIFF
--- a/naarang/BruteForce/BOJ_14501.js
+++ b/naarang/BruteForce/BOJ_14501.js
@@ -1,0 +1,56 @@
+const fs = require("fs");
+let input = fs.readFileSync("naarang/input.txt").toString().trim().split("\n");
+
+const N = Number(input[0]);
+
+let schedules = [];
+
+for (let i = 1; i <= N; i++) {
+  const [T, P] = input[i].split(" ").map(Number);
+  schedules.push([T, P]);
+}
+
+let dp = new Array(N + 1).fill(0);
+
+// 1일차
+const [T1, P1] = schedules[0];
+if (T1 === 1) dp[1] = P1;
+
+// 2일차 ~
+for (let i = 2; i <= N; i++) {
+  // i일차
+  let dayi = 0;
+  const [Ti, Pi] = schedules[i - 1];
+  if (Ti === 1) dayi = Pi;
+
+  dp[i] = dp[i - 1] + dayi;
+
+  // 앞쪽에서 새롭게 가능해진값 있는지 찾기
+  for (let j = i - 1; j > 0; j--) {
+    const [Tj, Pj] = schedules[j - 1];
+
+    if (i - j + 1 === Tj) {
+      dp[i] = Math.max(dp[i], dp[j - 1] + Pj);
+    }
+  }
+}
+
+console.log(dp[N]);
+
+/*
+
+DP와 BruteForce로 각각으로 풀어보기
+
+1) DP
+
+훨씬 효율적
+
+2) BruteForce
+
+: 해당 상담을 할 경우와 아닌 경우 모두 탐색하면 됨
+
+N의 크기가 작기 때문에 가능한 것 같은데... 크면 DP가 맞는듯!
+
+
+
+*/

--- a/naarang/GraphTraversal/BOJ_13023.js
+++ b/naarang/GraphTraversal/BOJ_13023.js
@@ -1,0 +1,48 @@
+const fs = require("fs");
+let input = fs.readFileSync("naarang/input.txt").toString().trim().split("\n");
+
+const [N, M] = input[0].split(" ").map(Number);
+const graph = {};
+
+for (let i = 1; i <= M; i++) {
+  const [start, end] = input[i].split(" ").map(Number);
+
+  graph[start] ? graph[start].push(end) : (graph[start] = [end]);
+  graph[end] ? graph[end].push(start) : (graph[end] = [start]);
+}
+
+const visited = new Array(N).fill(false);
+let findAnswer = false;
+
+const dfs = (student, depth) => {
+  if (findAnswer) return;
+
+  if (depth >= 5) {
+    findAnswer = true;
+    return;
+  }
+
+  visited[student] = true;
+
+  const children = graph[student] ?? [];
+
+  for (let child of children) {
+    if (!visited[child]) dfs(child, depth + 1);
+  }
+
+  visited[student] = false; // 방문 체크 해재!
+};
+
+for (let i = 0; i < N; i++) {
+  dfs(i, 1);
+}
+
+console.log(findAnswer ? 1 : 0);
+
+/*
+
+처음에 dfs를 stack으로 구현했는데 이게 아니라 재귀함수로 구현해서 
+
+탐색할 때 방문체크하고 재귀함수를 빠져나오면 방문제크를 해제해야 함! -> 다른 경로로 같은 노드를 탐색해야하기 때문에
+
+*/

--- a/naarang/GraphTraversal/BOJ_13549.js
+++ b/naarang/GraphTraversal/BOJ_13549.js
@@ -1,0 +1,36 @@
+const fs = require("fs");
+let input = fs.readFileSync("naarang/input.txt").toString().trim().split("\n");
+
+const [start, end] = input[0].split(" ").map(Number);
+
+const bfs = (initialTime, initialLocation) => {
+  let queue = [[initialTime, initialLocation]]; // [time, location]
+  let visited = new Array(100000).fill(false);
+  visited[start] = true;
+
+  while (queue.length > 0) {
+    const [time, location] = queue.shift();
+    visited[location] = true;
+
+    if (location === end) {
+      console.log(time);
+      return;
+    }
+
+    if (location <= 50000 && !visited[location * 2]) queue.unshift([time, location * 2]); // unshift로 앞에다가 두기!
+    if (location < 100000 && !visited[location + 1]) queue.push([time + 1, location + 1]);
+    if (location > 0 && !visited[location - 1]) queue.push([time + 1, location - 1]);
+  }
+};
+
+bfs(0, start);
+
+/*
+
+BFS로 간단하게 풀었는데 시간 초과..
+
+이미 탐색한 위치는 갈 필요없다! 먼저 도착한 경우가 이미 있으므로 ~
+
+아하! 2배로 이동하는 건 0초만 걸리는 것이므로 더 빨라서 가중치를 시간으로 두고 먼저 탐색해야 한다!
+
+*/

--- a/naarang/GraphTraversal/BOJ_2573.js
+++ b/naarang/GraphTraversal/BOJ_2573.js
@@ -1,0 +1,116 @@
+const fs = require("fs");
+let input = fs.readFileSync("naarang/input.txt").toString().trim().split("\n");
+
+const [N, M] = input[0].split(" ").map(Number);
+let board = [];
+
+for (let i = 1; i <= N; i++) {
+  const line = input[i].split(" ").map(Number);
+  board.push(line);
+}
+
+const directions = [
+  [-1, 0],
+  [1, 0],
+  [0, 1],
+  [0, -1],
+];
+
+const melting = () => {
+  let visitied = Array.from({ length: N }, () => new Array(M).fill(false));
+  let queue = [];
+
+  for (let i = 0; i < N; i++) {
+    for (let j = 0; j < M; j++) {
+      if (board[i][j] > 0) queue.push([i, j]);
+    }
+  }
+
+  if (queue.length === 0) return false; // 더 이상 녹을 것이 없으면!
+
+  for (let q of queue) {
+    const [x, y] = q;
+    visitied[x][y] = true;
+
+    let count = 0;
+    for (let [dx, dy] of directions) {
+      const nx = x + dx;
+      const ny = y + dy;
+
+      if (nx >= 0 && nx < N && ny >= 0 && ny < M && !visitied[nx][ny] && board[nx][ny] === 0) {
+        count++;
+      }
+    }
+
+    if (board[x][y] - count > 0) board[x][y] -= count;
+    else board[x][y] = 0;
+  }
+
+  return true;
+};
+
+const checkNum = () => {
+  let visitied = Array.from({ length: N }, () => new Array(M).fill(false));
+
+  const bfs = (initialX, initialY) => {
+    let index = 0;
+    let queue = [[initialX, initialY]];
+    visitied[initialX][initialY] = true;
+
+    while (queue.length > index) {
+      const [x, y] = queue[index++];
+
+      for (let [dx, dy] of directions) {
+        const nx = x + dx;
+        const ny = y + dy;
+
+        if (nx >= 0 && nx < N && ny >= 0 && ny < M && !visitied[nx][ny] && board[nx][ny] > 0) {
+          visitied[nx][ny] = true;
+          queue.push([nx, ny]);
+        }
+      }
+    }
+  };
+
+  let count = 0;
+  for (let i = 0; i < N; i++) {
+    for (let j = 0; j < M; j++) {
+      if (board[i][j] > 0 && !visitied[i][j]) {
+        count++;
+        bfs(i, j);
+      }
+      if (count >= 2) return true;
+    }
+  }
+};
+
+let answer = 1;
+while (true) {
+  const isAvailable = melting();
+  if (!isAvailable) {
+    console.log(0);
+    return;
+  }
+
+  const result = checkNum();
+
+  if (result) {
+    console.log(answer);
+    return;
+  }
+
+  answer++;
+}
+
+/*
+
+
+한 덩어리의 빙산이 두 덩어리로 분리되는 것을 어떻게 판단하지? 이것도 BFS로!
+
+1. 1년동안 녹이고
+2 섬이 2개 이상인지를 체크
+
+구현 문제 같았다! 차분히 조건을 해결해나가면 됐었고 시간초과 고민했는데 그냥 for문 돌려도 괜찮았다
+
+
+*/

--- a/naarang/GraphTraversal/BOJ_7569.js
+++ b/naarang/GraphTraversal/BOJ_7569.js
@@ -1,0 +1,66 @@
+const fs = require("fs");
+let input = fs.readFileSync("naarang/input.txt").toString().trim().split("\n");
+
+let inputIndex = 0;
+const [M, N, H] = input[inputIndex++].split(" ").map(Number);
+
+let board = [];
+
+for (let i = 0; i < H; i++) {
+  let xy = [];
+  for (let i = 0; i < N; i++) {
+    xy.push(input[inputIndex++].split(" ").map(Number));
+  }
+  board.push(xy);
+}
+
+const directions = [
+  [-1, 0, 0],
+  [1, 0, 0],
+  [0, -1, 0],
+  [0, 1, 0],
+  [0, 0, -1],
+  [0, 0, 1],
+];
+
+const bfs = () => {
+  let unripped = 0;
+  let queue = []; // [z, x, y, day]
+  let index = 0; // queue를 탐색할 index
+
+  for (let i = 0; i < H; i++) {
+    for (let j = 0; j < N; j++) {
+      for (let k = 0; k < M; k++) {
+        if (board[i][j][k] === 0) unripped++;
+        else if (board[i][j][k] === 1) queue.push([i, j, k, 0]);
+      }
+    }
+  }
+
+  if (unripped === 0) return 0;
+
+  while (index < queue.length) {
+    const [z, x, y, day] = queue[index++];
+
+    for (let [dz, dx, dy] of directions) {
+      const nz = z + dz;
+      const nx = x + dx;
+      const ny = y + dy;
+
+      if (nz >= 0 && nz < H && nx >= 0 && nx < N && ny >= 0 && ny < M && board[nz][nx][ny] === 0) {
+        queue.push([nz, nx, ny, day + 1]);
+        board[nz][nx][ny] = 1;
+        unripped--;
+      }
+    }
+  }
+
+  if (unripped > 0) return -1;
+
+  const [, , , day] = queue.pop();
+  return day;
+};
+
+console.log(bfs());
+
+// 7576 토마토 문제와 완전 똑같은 로직으로 풀었다! 2차원 배열 -> 3차원 배열로 확장한 것뿐!

--- a/naarang/GraphTraversal/BOJ_7576.js
+++ b/naarang/GraphTraversal/BOJ_7576.js
@@ -1,0 +1,72 @@
+const fs = require("fs");
+let input = fs.readFileSync("naarang/input.txt").toString().trim().split("\n");
+
+const [M, N] = input[0].split(" ").map(Number);
+let board = [];
+const directions = [
+  [-1, 0],
+  [1, 0],
+  [0, -1],
+  [0, 1],
+];
+
+for (let i = 1; i <= N; i++) {
+  const line = input[i].split(" ").map(Number);
+  board.push(line);
+}
+
+const bfs = () => {
+  let index = 0; // 큐의 처리 인덱스
+  let queue = []; // [x, y, day]
+  let unripped = 0; // 안 익은 과일 개수
+
+  // 처음에 1인 친구들의 좌표값 찾기
+  for (let i = 0; i < N; i++) {
+    for (let j = 0; j < M; j++) {
+      if (board[i][j] === 1) queue.push([i, j, 0]);
+      else if (board[i][j] === 0) unripped++;
+    }
+  }
+
+  if (unripped === 0) return 0;
+
+  while (index < queue.length) {
+    let [x, y, day] = queue[index++];
+    board[x][y] = 1;
+
+    for (const [dx, dy] of directions) {
+      const nx = x + dx;
+      const ny = y + dy;
+
+      // 범위 내에 있고 익지 않은 토마토일 경우
+      if (nx >= 0 && nx < N && ny >= 0 && ny < M && board[nx][ny] === 0) {
+        board[nx][ny] = 1;
+        queue.push([nx, ny, day + 1]);
+        unripped--;
+      }
+    }
+  }
+
+  if (unripped > 0) return -1;
+
+  const [, , day] = queue.pop();
+  return day;
+};
+
+console.log(bfs());
+
+/*
+
+시작점이 여러개인 BFS를 돌리는 방법은 그냥 모든 시작점을 큐에 넣고 BFS하기
+
+그냥 간단하게 bfs로 풀었더니 시간 초과 발생
+
+2가지 부분을 개선 
+
+1. queue를 이용할 때 shift를 이용하므로 배열의 맨 앞 요소를 제거하므로 O(n) 시간 복잡도가 발생
+
+-> 따라서 index로 처리함
+
+2. 과일이 모두 이미 익은 경우, 모두 익을 수 업는 경우를 각각 2중 for문으로 체크했는데 그러지 않고 최대한 bfs 시에 함께 체크되도록 함
+
+*/

--- a/naarang/README.md
+++ b/naarang/README.md
@@ -1,3 +1,15 @@
+#### Week 18 - Graph Traversal/Brute Force (24.01.13)
+
+| 유형            | 제목                                                                          | 풀이 |
+| --------------- | ----------------------------------------------------------------------------- | :--: |
+| Graph Traversal | [백준 13549 : 숨바꼭질 3](https://www.acmicpc.net/problem/13549)              |
+| Graph Traversal | [백준 13023 : ABCDE](https://www.acmicpc.net/problem/13023)                   |
+| Graph Traversal | [백준 7576 : 토마토](https://www.acmicpc.net/problem/7576)                    |
+| Graph Traversal | [백준 7569 : 토마토](https://www.acmicpc.net/problem/7569)                    |
+| Graph Traversal | [백준 2573 : 빙산](https://www.acmicpc.net/problem/2573)                      |
+| Brute Force     | [백준 14501 : 퇴사](https://www.acmicpc.net/problem/14501)                    |
+| Brute Force     | [백준 2961 : 도영이가 만든 맛있는 음식](https://www.acmicpc.net/problem/2961) |
+
 #### Week 17 - Graph Traversal (24.01.06)
 
 | 유형            | 제목                                                                | 풀이 |

--- a/naarang/README.md
+++ b/naarang/README.md
@@ -17,8 +17,6 @@
 | Graph Traversal | [백준 1325 : 효율적인 해킹](https://www.acmicpc.net/problem/1325)   |
 | Graph Traversal | [백준 14940 : 쉬운 최단거리](https://www.acmicpc.net/problem/14940) |
 | Graph Traversal | [백준 16918 : 봄버맨](https://www.acmicpc.net/problem/16918)        |
-| Graph Traversal | [백준 13549 : 숨바꼭질 3](https://www.acmicpc.net/problem/13549)    |
-| Graph Traversal | [백준 13023 : ABCDE](https://www.acmicpc.net/problem/13023)         |
 
 #### Week 16 - Implementation/Graph Traversal (24.12.30)
 


### PR DESCRIPTION
## ✅ 체크리스트

<!-- 푼 문제들을 체크해주세요 -->

- [x] 백준 13549 : 숨바꼭질 3
- [x] 백준 13023 : ABCDE
- [x] 백준 7576 : 토마토
- [x] 백준 7569 : 토마토
- [x] 백준 2573 : 빙산
- [x] 백준 14501 : 퇴사

## ✏️ 공부 내용

<!-- 새롭게 알게 된 내용이나 공부한 내용을 정리해주세요 -->


### 백준 13549 : 숨바꼭질 3

BFS로 간단하게 풀었는데 시간 초과..

이미 탐색한 위치는 갈 필요없다! 먼저 도착한 경우가 이미 있으므로 ~

2배로 이동하는 건 0초만 걸리는 것이므로 더 빨라서 가중치를 시간으로 두고 먼저 탐색해야 한다!

---

### 백준 13023 : ABCDE

처음에 dfs를 stack으로 구현했는데 이게 아니라 재귀함수로 구현해서 

탐색할 때 방문체크하고 재귀함수를 빠져나오면 방문제크를 해제해야 함! -> 다른 경로로 같은 노드를 탐색해야하기 때문에

--- 

### 백준 7576 : 토마토

시작점이 여러개인 BFS를 돌리는 방법은 그냥 모든 시작점을 큐에 넣고 BFS하기

그냥 간단하게 bfs로 풀었더니 시간 초과 발생

2가지 부분을 개선 

1. queue를 이용할 때 shift를 이용하므로 배열의 맨 앞 요소를 제거하므로 O(n) 시간 복잡도가 발생

-> 따라서 index로 처리함

2. 과일이 모두 이미 익은 경우, 모두 익을 수 업는 경우를 각각 2중 for문으로 체크했는데 그러지 않고 최대한 bfs 시에 함께 체크되도록 함

---

### 백준 7569 : 토마토

7576 토마토 문제와 완전 똑같은 로직으로 풀었다! 2차원 배열 -> 3차원 배열로 확장한 것뿐!

---

### 백준 2573 : 빙산

한 덩어리의 빙산이 두 덩어리로 분리되는 것을 어떻게 판단하지? 이것도 BFS로!

1. 1년동안 녹이고
2 섬이 2개 이상인지를 체크

구현 문제 같았다! 차분히 조건을 해결해나가면 됐었고 시간초과 고민했는데 그냥 for문 돌려도 괜찮았다

---

### 백준 14501 : 퇴사

DP와 BruteForce로 각각으로 풀어보기

1) DP

: 각 날짜에서 최대로 가능한 상담 수익을 갱신

2) BruteForce

: 해당 상담을 할 경우와 아닌 경우 모두 탐색하면 됨


## 💬 논의 사항

<!-- 논의하고 싶은 사항이나 기타 내용이 있다면 작성해주세요 -->
