### PR TITLE
[Brute Force, Geometric] 3주차

### DIFF
--- a/Goraniiii/Brute Force/BOJ_10972.cpp
+++ b/Goraniiii/Brute Force/BOJ_10972.cpp
@@ -1,0 +1,62 @@
+/*
+BOJ 10972
+Brute Force
+다음 순열
+S3
+*/
+
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+bool next_permutation_by_me(vector<int>& arr) {
+  int n = arr.size();
+
+  int i = n - 2;
+  while(i >= 0 && arr[i] >= arr[i + 1]) {
+    i--;
+  }
+
+  if(i < 0) {
+    return false;
+  }
+
+  int j = n - 1;
+  while(arr[j] <= arr[i]) {
+    j--;
+  }
+
+  swap(arr[i], arr[j]);
+
+  reverse(arr.begin() + i + 1, arr.end());
+
+  return true;
+}
+
+int main() {
+  int N;
+  vector<int> numbers;
+  cin >> N;
+
+  for(int i = 0; i < N; i++) {
+    int num;
+    cin >> num;
+
+    numbers.push_back(num);
+  }
+
+  // if(next_permutation(numbers.begin(), numbers.end())) {
+  if(next_permutation_by_me(numbers)) {
+    for(int num : numbers) {
+      cout << num << " ";
+    }
+  }
+  else {
+    cout << -1;
+  }
+  cout << endl;
+
+  return 0;
+}

--- a/Goraniiii/Geomatric/BOJ_17386.cpp
+++ b/Goraniiii/Geomatric/BOJ_17386.cpp
@@ -1,0 +1,43 @@
+/*
+BOJ 17386
+Geomatric
+선분 교차 1
+G3
+*/
+
+#include <iostream>
+
+using namespace std;
+
+int ccw(long x1, long y1, long x2, long y2, long x3, long y3) {
+  long long ccw = (x2 - x1) * (y3 - y1) - (x3 - x1) * (y2 - y1);
+  if(ccw < 0) {
+    return -1;
+  }
+  else if(ccw > 0) {
+    return 1;
+  }
+  else {
+    return 0;
+  }
+}
+
+int main() {
+  int x1, y1, x2, y2, x3, y3, x4, y4;
+
+  cin >> x1 >> y1 >> x2 >> y2;
+  cin >> x3 >> y3 >> x4 >> y4;
+
+  // ccw 이용
+  int ccw123 = ccw(x1, y1, x2, y2, x3, y3);
+  int ccw124 = ccw(x1, y1, x2, y2, x4, y4);
+  int ccw341 = ccw(x3, y3, x4, y4, x1, y1);
+  int ccw342 = ccw(x3, y3, x4, y4, x2, y2);
+
+  if(ccw123 * ccw124 < 0 && ccw341 * ccw342 < 0) {
+    cout << "1" << endl;
+  }
+  else {
+    cout << "0" << endl;
+  }
+}

--- a/Goraniiii/Geomatric/BOJ_17387.cpp
+++ b/Goraniiii/Geomatric/BOJ_17387.cpp
@@ -1,0 +1,54 @@
+/*
+BOJ 17387
+Geomatric
+선분 교차 2
+G2
+*/
+
+#include <iostream>
+
+using namespace std;
+
+int ccw(long x1, long y1, long x2, long y2, long x3, long y3) {
+  long long ccw = (x2 - x1) * (y3 - y1) - (x3 - x1) * (y2 - y1);
+  if(ccw < 0) {
+    return -1;
+  }
+  else if(ccw > 0) {
+    return 1;
+  }
+  else {
+    return 0;
+  }
+}
+
+int main() {
+  int x1, y1, x2, y2, x3, y3, x4, y4;
+
+  cin >> x1 >> y1 >> x2 >> y2;
+  cin >> x3 >> y3 >> x4 >> y4;
+
+  // ccw 이용
+  int ccw123 = ccw(x1, y1, x2, y2, x3, y3);
+  int ccw124 = ccw(x1, y1, x2, y2, x4, y4);
+  int ccw341 = ccw(x3, y3, x4, y4, x1, y1);
+  int ccw342 = ccw(x3, y3, x4, y4, x2, y2);
+
+  if(ccw123 * ccw124 <= 0 && ccw341 * ccw342 <= 0) {
+    if(ccw123 == 0 && ccw124 == 0 && ccw341 == 0 && ccw342 == 0) {
+      if (min(x1, x2) <= max(x3, x4) && max(x1, x2) >= min(x3, x4) && min(y1, y2) <= max(y3, y4) && max(y1, y2) >= min(y3, y4)) {
+        cout << "1" << endl;
+      }
+      else {
+        cout << "0" << endl;
+      }
+    }
+    else {
+      cout << "1" << endl;
+    }
+    
+  }
+  else {
+    cout << "0" << endl;
+  }
+}


### PR DESCRIPTION
## ✅ 체크리스트

<!-- 푼 문제들을 체크해주세요 -->

- [x] 10972 : 다음 순열
- [x] 17386 : 선분 교차 1
- [x] 17387 : 선분 교차 2

## ✏️ 공부 내용

<!-- 새롭게 알게 된 내용이나 공부한 내용을 정리해주세요 -->
<b>10972 : 다음 순열</b>
순열을 정렬 후 비교할 때 다음 순열의 숫자 배치 변화를 알기 위해서는 피벗 개념이 필요하다
가장 끝에서부터 감소하는 부분: 순열의 피벗
피벗과 스왑 위치를 찾는 과정에서 규칙을 찾는데 어려움을 겪었다.

이미 C++의 next_permutation 함수가 구현되어 있다.
다만 내부 알고리즘의 이해를 위해 직접 구현하는 것이 이 문제의 목표

next permutation 자체가 brute force인 것이 아니라, 이 함수를 이용하면 brute force를 수행할 때 다음 경우의 수로 순차적으로 넘어갈 수 있다.

<b>17386 : 선분 교차 1</b>
두 선분의 교차 여부를 판단
선분 교차 1 문제에서는 주어진 두 선분 중 어느 세 점도 일직선상에 있지 않다.
지난번에 푼 ccw 문제로 세 점으로 결정되는 각도를 구할 수 있게 되었다.
즉 ccw == 0 인 케이스는 존재하지 않는다.
한 선분을 기준으로 다른 선분의 두 점이 서로 반대에 있는, 즉 반대 선분 두 점의 ccw 곱이 음수여야한다.
반대쪽 선분을 기준으로도 마찬가지로 수행해서, 각 선분 기준의 ccw 곱이 모두 음수이면 교차.

다만 ccw를 그대로 이용하면서 값의 범위를 신경써야했다
최근 python을 많이 사용하다보니 타입과 크기를 잘 신경쓰지 않게되어 노력 필요

<b>17387 : 선분 교차 2</b>
17386 문제와 이어서, 이전 문제에서 고려했던 사항 이외에 세 점이 일직선상에 있는 케이스가 추가되었다.
여기서 다시 케이스를 나누어 세 점만 일직선 한 점은 아닌 경우와, 네 점 모두 일직선상에 있는 경우로 나눈다.
네 점 모두 일직선상에 있는 경우, 겹치는지 여부를 판단해줘야한다.

## 💬 논의 사항

<!-- 논의하고 싶은 사항이나 기타 내용이 있다면 작성해주세요 -->
기하 알고리즘 문제를 시작했는데, 코테에 자주 나오는 유형은 아니라 알고리즘 공부를 어떤 목적으로 하고있는지 생각중