### PR TITLE
[Implement,DFS] 8주차

### DIFF
--- a/rlaalsghks8/src/implement/Problem13414.java
+++ b/rlaalsghks8/src/implement/Problem13414.java
@@ -1,0 +1,36 @@
+package implement;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedHashMap;
+import java.util.StringTokenizer;
+
+public class Problem13414 {
+    public static void main(String[] args)throws IOException {
+
+        LinkedHashMap<String, Integer> map = new LinkedHashMap<>();
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine()," ");
+        int K = Integer.parseInt(st.nextToken());
+        int L = Integer.parseInt(st.nextToken());
+
+        for(int i=0; i<L; i++){
+            String stNum = br.readLine();
+            map.remove(stNum);
+            map.put(stNum,i);
+        }
+
+        int count = 0;
+        for(String id : map.keySet()){
+            System.out.println(id);
+            count++;
+            if(count==K)
+                break;
+        }
+
+
+
+    }
+}

--- a/rlaalsghks8/src/implement/Problem1783.java
+++ b/rlaalsghks8/src/implement/Problem1783.java
@@ -1,0 +1,32 @@
+package implement;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Problem1783 {
+    public static void main(String[] args)throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine()," ");
+        int N = Integer.parseInt(st.nextToken()); //세로
+        int M = Integer.parseInt(st.nextToken());  //가로
+
+
+
+
+        int count = 0;
+        if (N == 1) {
+            count = 1;
+        } else if (N == 2) {
+            count = Math.min(4, ((M + 1) / 2));
+        } else if (M < 7) {
+            count = Math.min(4, M);
+        } else if(M >= 7){
+            count = M - 2;
+        }
+
+        System.out.println(count);
+    }
+}

--- a/rlaalsghks8/src/search/Problem11724.java
+++ b/rlaalsghks8/src/search/Problem11724.java
@@ -1,0 +1,66 @@
+package search;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Problem11724 {
+    static int N,M;
+    static int[][] board;
+    static boolean[] visited;
+    static int count = 0;
+
+    public static void main(String[] args)throws IOException {
+        BufferedReader br =new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine()," ");
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+
+
+        board = new int[N+1][N+1];
+        visited = new boolean[N+1];
+
+
+        for(int i=1; i<=M; i++){
+            st = new StringTokenizer(br.readLine()," ");
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt(st.nextToken());
+
+            board[x][y] = 1;
+            board[y][x] = 1;
+
+        }
+
+        for(int i=1; i<=N; i++){
+            if(!visited[i]){
+                bfs(i);
+                count++;
+            }
+        }
+
+        System.out.print(count);
+
+    }
+
+    public static void bfs(int start){
+        Queue<Integer> q = new LinkedList<>();
+        visited[start] = true;
+        q.offer(start);
+        while(!q.isEmpty()){
+            int s = q.poll();
+            for(int i=1; i<=N; i++){
+                if(board[s][i]==1 && !visited[i]){
+                    q.offer(i);
+                    visited[i] = true;
+                }
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
## ✅ 체크리스트

<!-- 푼 문제들을 체크해주세요 -->

- [x] 13414번 : 수강신청
- [x] 1783번 : 병든 나이트
- [x] 11724번 : 연결요소의 개수

## ✏️ 공부 내용
13414번
자바 문법 부족, 자료구조 개념 부족
LinkedHashMap은  해시 맵과 연결 리스트를 결합한 구현체로, 삽입 순서를 기억한다. 삽입 순서를 유지하면서 해시 맵의 기능을 사용할 수 있다.
문제를 해결하는데 가장 중요한 부분
1783번
생각보다 쉬움. 조건 설정해서 가로 +2를 먼저 했다 생각하고 나머지는 +1로만 세로는 -2,+2만 왔다갔다 하는 걸로하면 되는거라 나머지는 가로의 -2를 한다음에 나머지 +1로만 그리고 4번이하 이동은 제약조건 설정하면 끝
11724번
bfs,dfs 공부 끝나면 추천 문제긴함 현대오토에버에서 독립점 문제랑 유사
bfs로 풀었고 방문한 곳이 아니면 bfs작동 및 요소(count) 갯수 ++ 하면 됨

<!-- 새롭게 알게 된 내용이나 공부한 내용을 정리해주세요 -->

## 💬 논의 사항

<!-- 논의하고 싶은 사항이나 기타 내용이 있다면 작성해주세요 -->
