### PR TITLE
{DP} 8주차

### DIFF
--- a/JungYujin/DP/계단오르기2579.java
+++ b/JungYujin/DP/계단오르기2579.java
@@ -1,0 +1,29 @@
+package DP;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class 계단오르기2579 {
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int[] stair = new int[301];
+        int[] dp = new int[301];
+
+        for(int i=1;i<=n;i++){
+            st = new StringTokenizer(br.readLine());
+            stair[i] = Integer.parseInt(st.nextToken());
+        }
+        dp[1] = stair[1];
+        dp[2] = stair[1]+stair[2];
+        dp[3] = Math.max(stair[1],stair[2]) + stair[3];
+            
+
+        for(int i=4;i<=n;i++){
+            dp[i] = Math.max(dp[i-3]+stair[i-1],dp[i-2])+stair[i];
+        }
+        System.out.println(dp[n]);
+    }
+}

--- a/JungYujin/DP/돌게임9655.java
+++ b/JungYujin/DP/돌게임9655.java
@@ -1,0 +1,16 @@
+package DP;
+
+import java.util.Scanner;
+
+public class 돌게임9655 {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int n = sc.nextInt();
+        String winner="";
+        if(n%2==0){
+            System.out.println("CY");
+        }else{
+            System.out.println("SK");
+        }
+    }
+}

--- a/JungYujin/DP/일이삼더하기2_9095.java
+++ b/JungYujin/DP/일이삼더하기2_9095.java
@@ -1,0 +1,21 @@
+package DP;
+
+import java.util.Scanner;
+
+public class 일이삼더하기2_9095 {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int[] arr = new int[11];
+        arr[1] = 1;
+        arr[2] = 2;
+        arr[3] = 4;
+        int tc = sc.nextInt();
+        for(int i=4;i<11;i++){
+            arr[i] = arr[i-1] + arr[i-2] + arr[i-3];
+        }
+        for(int i=0;i<tc;i++){
+            int n = sc.nextInt();
+            System.out.println(arr[n]);
+        }
+    }
+}


### PR DESCRIPTION
## ✅ 체크리스트

<!-- 푼 문제들을 체크해주세요 -->

- [x] 9655 : 돌 게임
- [x] 2579 : 계단오르기
- [x] 9095 : 1,2,3 더하기

## ✏️ 공부 내용

9655 : 돌 게임
돌을 가져갈 수 있는 개수가 홀수 개이다 보니
돌의 개수가 홀수이면 먼저 시작한 사람이, 짝수이면 늦게 시작한 사람이 이기게 되어있다.

2579 : 계단오르기
매 계단마다 [현재-2]를 밟고 올라온 점수와 [현재-3 + 현재-1]을 밟고 온 점수를 비교하여 큰 값과 현재의 값을 더한다.

9095 : 1,2,3 더하기
먼저 1,2,3을 만들 수 있는 경우의 수를 배열에 저장하고
4부터 11까지 반복문을 돌면서 값을 채운다.
4를 예로 들면 1을 만드는 경우에는 3을 더하고, 2를 만드는 경우에는 2를 더하고, 3을 만드는 경우에는 1을 더해주면 4를 만들 수 있기 때문에 [1을 만드는 경우의 수 + 2를 만드는 경우의 수 + 3을 만드는 경우의 수 = 4를 만드는 경우의 수] 가 된다. 
따라서 점화식은 arr[i] = arr[i-1] + arr[i-2] + arr[i-3]가 된다.

## 💬 논의 사항

<!-- 논의하고 싶은 사항이나 기타 내용이 있다면 작성해주세요 -->
