### PR TITLE
[DP] 24주차

### DIFF
--- a/naarang/DynamicProgramming/BOJ_2302.js
+++ b/naarang/DynamicProgramming/BOJ_2302.js
@@ -1,0 +1,40 @@
+const fs = require("fs");
+let input = fs.readFileSync("naarang/input.txt").toString().trim().split("\n");
+
+const N = Number(input[0]);
+const M = Number(input[1]);
+
+const vip = new Set();
+for (let i = 2; i < 2 + M; i++) {
+  vip.add(Number(input[i]));
+}
+
+const dp = Array.from({ length: N + 1 }, () => [0n, 0n]);
+
+dp[0][0] = 1n;
+dp[1][0] = 1n;
+if (!vip.has(1) && !vip.has(2)) {
+  dp[1][1] = 1n;
+}
+
+for (let i = 2; i < N; i++) {
+  dp[i][0] = BigInt(dp[i - 1][0]) + BigInt(dp[i - 1][1]); // 교차 안함
+  if (!vip.has(i) && !vip.has(i + 1)) {
+    dp[i][1] = BigInt(dp[i - 1][0]); // 교차함
+  }
+}
+
+console.log(String(dp[N - 1][0] + dp[N - 1][1]));
+
+/*
+
+이웃한 두 칸끼리 바꾸거나 안바꾸거나로 경우를 구분 가능
+dp[n][0] : n번 자리와 n+1번 자리를 교차하지 않음
+dp[n][1] : n번 자리와 n+1번 자리를 교차
+-> 교차가 가능한지 살펴볼 때는 n번 자리와 n+1번 자리가 모두 vip가 아님을 확인!
+
+
+오류) 1 1 1 의 입력이 들어왔을 때 1이라는 답이 나와야하는데 0이라는 값이 나옴
+dp[0][0] = 1n;으로 초기화 필요!
+
+*/

--- a/naarang/DynamicProgramming/BOJ_2565.js
+++ b/naarang/DynamicProgramming/BOJ_2565.js
@@ -1,0 +1,54 @@
+const fs = require("fs");
+let input = fs.readFileSync("naarang/input.txt").toString().trim().split("\n");
+
+const N = Number(input[0]);
+
+const lines = [];
+
+for (let i = 1; i <= N; i++) {
+  const [start, end] = input[i].split(" ").map(Number);
+  lines.push([start, end]);
+}
+
+// 전기줄의 시작점-종료점 중에서 시작점을 기준으로 오름차순 정렬
+lines.sort((a, b) => a[0] - b[0]);
+
+const lis = [lines[0][1]];
+
+const binarySearch = (target) => {
+  let start = 0;
+  let end = lis.length - 1;
+
+  while (start < end) {
+    let mid = Math.floor((start + end) / 2);
+
+    if (lis[mid] >= target) {
+      end = mid;
+    } else {
+      start = mid + 1;
+    }
+  }
+
+  return start;
+};
+
+for (let i = 1; i < N; i++) {
+  target = lines[i][1];
+
+  if (lis[lis.length - 1] < target) {
+    lis.push(target);
+  } else {
+    const index = binarySearch(target);
+    lis[index] = target;
+  }
+}
+
+console.log(N - lis.length);
+
+/*
+각 전기줄마다 교차되는 전기줄을 저장하고 교차되는 것이 많은 순으로 제거하면 되지 않나? 라고 처음에 생각했는데 이 문제는 LIS를 떠올리는 것이 핵심이었다!
+
+"A와 B가 모두 증가하는 형태면 교차가 만들어지지 않음!" -> 교차가 만들어지지 않는 최대 증가수열을 구하자 -> 전체 전깃줄 개수 - LIS 길이 = 제거할 전깃줄 수
+
+O(NlogN)을 가지는 이분탐색을 이용한 LIS로 구현
+*/

--- a/naarang/README.md
+++ b/naarang/README.md
@@ -1,3 +1,11 @@
+#### Week 31 - Dynamic Programming (25.06.16)
+
+| 유형                | 제목                                                                   | 풀이 |
+| ------------------- | ---------------------------------------------------------------------- | :--: |
+| Dynamic Programming | [백준 2302 : 극장 좌석](https://www.acmicpc.net/problem/2302)          |
+| Dynamic Programming | [백준 2565 : 전깃줄](https://www.acmicpc.net/problem/2565)             |
+| Dynamic Programming | [백준 15989 : 1, 2, 3 더하기 4](https://www.acmicpc.net/problem/15989) |
+
 #### Week 30 - Tree DP (25.06.09)
 
 | 유형    | 제목                                                                | 풀이 |


### PR DESCRIPTION
## ✅ 체크리스트

<!-- 푼 문제들을 체크해주세요 -->

- [x] 백준 2302 : 극장 좌석
- [x] 백준 2565 : 전깃줄

## ✏️ 공부 내용

<!-- 새롭게 알게 된 내용이나 공부한 내용을 정리해주세요 -->

### 백준 2302 : 극장 좌석

이웃한 두 칸끼리 바꾸거나 안바꾸거나로 경우를 구분 가능
dp[n][0] : n번 자리와 n+1번 자리를 교차하지 않음
dp[n][1] : n번 자리와 n+1번 자리를 교차
-> 교차가 가능한지 살펴볼 때는 n번 자리와 n+1번 자리가 모두 vip가 아님을 확인!


오류) 1 1 1 의 입력이 들어왔을 때 1이라는 답이 나와야하는데 0이라는 값이 나옴
dp[0][0] = 1n;으로 초기화 필요!

---

### 백준 2565 : 전깃줄

각 전기줄마다 교차되는 전기줄을 저장하고 교차되는 것이 많은 순으로 제거하면 되지 않나? 라고 처음에 생각했는데 이 문제는 LIS를 떠올리는 것이 핵심이었다!

"A와 B가 모두 증가하는 형태면 교차가 만들어지지 않음!" -> 교차가 만들어지지 않는 최대 증가수열을 구하자 -> 전체 전깃줄 개수 - LIS 길이 = 제거할 전깃줄 수

O(NlogN)을 가지는 이분탐색을 이용한 LIS로 구현


## 💬 논의 사항

<!-- 논의하고 싶은 사항이나 기타 내용이 있다면 작성해주세요 -->
